### PR TITLE
Add JaCoCo plugin and unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,8 +145,28 @@
 		</dependency>
 	</dependencies>
 
-	<build>
-		<plugins>
+        <build>
+                <plugins>
+
+                        <plugin>
+                                <groupId>org.jacoco</groupId>
+                                <artifactId>jacoco-maven-plugin</artifactId>
+                                <version>0.8.8</version>
+                                <executions>
+                                        <execution>
+                                                <goals>
+                                                        <goal>prepare-agent</goal>
+                                                </goals>
+                                        </execution>
+                                        <execution>
+                                                <id>report</id>
+                                                <phase>test</phase>
+                                                <goals>
+                                                        <goal>report</goal>
+                                                </goals>
+                                        </execution>
+                                </executions>
+                        </plugin>
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/ru/sberTechSobes/parkingProject/controller/GlobalExceptionHandlerTest.java
+++ b/src/test/java/ru/sberTechSobes/parkingProject/controller/GlobalExceptionHandlerTest.java
@@ -1,0 +1,26 @@
+package ru.sberTechSobes.parkingProject.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    void handleBusinessExceptionReturnsBadRequest() {
+        ResponseEntity<String> response = handler.handleBusinessException(new IllegalStateException("m"));
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("m", response.getBody());
+    }
+
+    @Test
+    void handleOtherExceptionsReturnsServerError() {
+        ResponseEntity<String> response = handler.handleOtherExceptions(new RuntimeException());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("Внутренняя ошибка сервиса", response.getBody());
+    }
+}

--- a/src/test/java/ru/sberTechSobes/parkingProject/controller/ParkingControllerTest.java
+++ b/src/test/java/ru/sberTechSobes/parkingProject/controller/ParkingControllerTest.java
@@ -1,0 +1,78 @@
+package ru.sberTechSobes.parkingProject.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import ru.sberTechSobes.parkingProject.enumeration.VehicleType;
+import ru.sberTechSobes.parkingProject.service.ParkingService;
+import ru.sberTechSobes.parkingProject.service.dto.*;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ParkingController.class)
+@Import(GlobalExceptionHandler.class)
+class ParkingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ParkingService parkingService;
+
+    @Test
+    void registerEntryReturnsCreated() throws Exception {
+        ParkingEntryResponse resp = new ParkingEntryResponse("A", VehicleType.SEDAN, LocalDateTime.now());
+        when(parkingService.registerEntry(any())).thenReturn(resp);
+
+        mockMvc.perform(post("/api/v1/parking/entry")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"carNumber\":\"A\",\"vehicleType\":\"SEDAN\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.vehicleNumber").value("A"))
+                .andExpect(jsonPath("$.vehicleType").value("SEDAN"));
+    }
+
+    @Test
+    void registerExitReturnsOk() throws Exception {
+        ParkingExitResponse resp = new ParkingExitResponse("A", LocalDateTime.now());
+        when(parkingService.registerExit(any())).thenReturn(resp);
+
+        mockMvc.perform(post("/api/v1/parking/exit")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"carNumber\":\"A\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.vehicleNumber").value("A"));
+    }
+
+    @Test
+    void getReportReturnsOk() throws Exception {
+        ParkingReportResponse resp = new ParkingReportResponse(1, 1, 10.0, 1, 99);
+        when(parkingService.getReport(any(), any())).thenReturn(resp);
+
+        mockMvc.perform(get("/api/v1/parking/report")
+                .param("start_date", "2020-01-01T00:00:00")
+                .param("end_date", "2020-01-02T00:00:00"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.entries").value(1));
+    }
+
+    @Test
+    void handleExceptionReturnsBadRequest() throws Exception {
+        when(parkingService.registerEntry(any())).thenThrow(new IllegalStateException("err"));
+
+        mockMvc.perform(post("/api/v1/parking/entry")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"carNumber\":\"A\",\"vehicleType\":\"SEDAN\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("err"));
+    }
+}

--- a/src/test/java/ru/sberTechSobes/parkingProject/service/ParkingServiceImplTest.java
+++ b/src/test/java/ru/sberTechSobes/parkingProject/service/ParkingServiceImplTest.java
@@ -1,0 +1,126 @@
+package ru.sberTechSobes.parkingProject.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import ru.sberTechSobes.parkingProject.entity.ParkingSession;
+import ru.sberTechSobes.parkingProject.enumeration.VehicleType;
+import ru.sberTechSobes.parkingProject.repository.ParkingSessionRepository;
+import ru.sberTechSobes.parkingProject.service.dto.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ParkingServiceImplTest {
+
+    @Mock
+    private ParkingSessionRepository repository;
+
+    private ParkingServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ParkingServiceImpl(repository);
+    }
+
+    @Test
+    void registerEntryCreatesSession() {
+        ParkingEntryRequest request = new ParkingEntryRequest();
+        request.setCarNumber("A123AA");
+        request.setVehicleType("sedan");
+
+        when(repository.findByCarNumberAndExitTimeIsNull("A123AA"))
+                .thenReturn(Optional.empty());
+        ArgumentCaptor<ParkingSession> captor = ArgumentCaptor.forClass(ParkingSession.class);
+
+        ParkingEntryResponse response = service.registerEntry(request);
+
+        verify(repository).save(captor.capture());
+        ParkingSession saved = captor.getValue();
+
+        assertEquals("A123AA", saved.getCarNumber());
+        assertEquals(VehicleType.SEDAN, saved.getVehicleType());
+        assertNotNull(saved.getEntryTime());
+        assertEquals(saved.getEntryTime(), response.getEntryTime());
+        assertEquals("A123AA", response.getVehicleNumber());
+        assertEquals(VehicleType.SEDAN, response.getVehicleType());
+    }
+
+    @Test
+    void registerEntryThrowsWhenAlreadyOnParking() {
+        ParkingEntryRequest request = new ParkingEntryRequest();
+        request.setCarNumber("B321BB");
+        request.setVehicleType("SUV");
+
+        when(repository.findByCarNumberAndExitTimeIsNull("B321BB"))
+                .thenReturn(Optional.of(new ParkingSession()));
+
+        assertThrows(IllegalStateException.class, () -> service.registerEntry(request));
+    }
+
+    @Test
+    void registerExitUpdatesSession() {
+        ParkingExitRequest request = new ParkingExitRequest();
+        request.setCarNumber("C456CC");
+        ParkingSession session = new ParkingSession();
+        session.setCarNumber("C456CC");
+        session.setEntryTime(LocalDateTime.now().minusHours(1));
+
+        when(repository.findByCarNumberAndExitTimeIsNull("C456CC"))
+                .thenReturn(Optional.of(session));
+
+        ArgumentCaptor<ParkingSession> captor = ArgumentCaptor.forClass(ParkingSession.class);
+
+        ParkingExitResponse response = service.registerExit(request);
+
+        verify(repository).save(captor.capture());
+        ParkingSession saved = captor.getValue();
+        assertNotNull(saved.getExitTime());
+        assertEquals(saved.getExitTime(), response.getExitTime());
+        assertEquals("C456CC", response.getVehicleNumber());
+    }
+
+    @Test
+    void registerExitThrowsWhenNotFound() {
+        ParkingExitRequest request = new ParkingExitRequest();
+        request.setCarNumber("Z999ZZ");
+
+        when(repository.findByCarNumberAndExitTimeIsNull("Z999ZZ"))
+                .thenReturn(Optional.empty());
+
+        assertThrows(IllegalStateException.class, () -> service.registerExit(request));
+    }
+
+    @Test
+    void getReportReturnsStatistics() {
+        LocalDateTime start = LocalDateTime.of(2020, 1, 1, 0, 0);
+        LocalDateTime end = start.plusDays(1);
+
+        ParkingSession s1 = new ParkingSession(1L, "A", VehicleType.SEDAN,
+                start.plusHours(1), start.plusHours(2));
+        ParkingSession s2 = new ParkingSession(2L, "B", VehicleType.SUV,
+                start.plusHours(3), start.plusHours(3).plusMinutes(30));
+        ParkingSession s3 = new ParkingSession(3L, "C", VehicleType.TRUCK,
+                start.plusHours(4), null);
+
+        when(repository.findAllByEntryTimeBetween(start, end))
+                .thenReturn(List.of(s1, s2, s3));
+        when(repository.countByExitTimeIsNull()).thenReturn(5L);
+
+        ParkingReportResponse report = service.getReport(start, end);
+
+        assertEquals(3L, report.getEntries());
+        assertEquals(2L, report.getExits());
+        assertEquals(45.0, report.getAvgDurationMinutes(), 0.1);
+        assertEquals(5L, report.getOccupiedPlaces());
+        assertEquals(95L, report.getFreePlaces());
+    }
+}


### PR DESCRIPTION
## Summary
- add JaCoCo maven plugin
- add unit tests for `ParkingServiceImpl`
- add web layer tests for `ParkingController` and exception handler

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68471cd35f14832789f98c1fecb967d0